### PR TITLE
Add option for three sizes of placeholder images to ipsum parameter

### DIFF
--- a/front/contents/readme.md
+++ b/front/contents/readme.md
@@ -302,6 +302,12 @@ String schemas may optionally have a hint, which is specified with the `"ipsum"`
 
   - <span class="api-str">`"long"`</span> - multiple paragraphs
 
+  - <span class="api-str">`"small image"`</span> - URL for an image with both dimensions between 100px and 250px
+
+  - <span class="api-str">`"medium image"`</span> - URL for an image with both dimensions between 250px and 500px
+
+  - <span class="api-str">`"large image"`</span> - URL for an image with both dimensions between 500px and 900px
+
 ## Bugs
 
 Please report bugs and feature requests on the [issues page](http://github.com/jonahkagan/schematic-ipsum/issues). Pull requests are welcome!

--- a/front/contents/readme.md
+++ b/front/contents/readme.md
@@ -22,7 +22,8 @@ Say we wanted to model users with JSON objects like this one:
   "name": "Ada Lovelace",
   "email": "ada@geemail.com",
   "bio": "First programmer. No big deal.",
-  "age": 198
+  "age": 198,
+  "avatar": "http://hhhhold.com/s?18732"
 }
 ```
 
@@ -36,7 +37,8 @@ A JSON schema for this object might look like this:
     "name": { "type": "string" },
     "email": { "type": "string", "format": "email" },
     "bio": { "type": "string" },
-    "age": { "type": "integer" }
+    "age": { "type": "integer" },
+    "avatar": { "type": "string" }
   }
 }
 ```
@@ -58,7 +60,8 @@ Content-Type: application/json
     "name": { "type": "string" },
     "email": { "type": "string", "format": "email" },
     "bio": { "type": "string" },
-    "age": { "type": "integer" }
+    "age": { "type": "integer" },
+    "avatar": { "type": "string" }
   }
 }
 ```
@@ -70,7 +73,8 @@ Content-Type: application/json
   "name": "Its upperparts and sides are grey, but elongated grey feathers with black central stripes are draped across the back from the shoulder area.",
   "email": "rita_sakellariou@vancouver.edu",
   "bio": "Wintjiya came from an area north-west or north-east of Walungurru (the Pintupi-language name for Kintore, Northern Territory).",
-  "age": 39
+  "age": 39,
+  "avatar": "However, she refused to admit her guilt to the end, and had given no evidence against any others of the accused."
 }
 ```
 
@@ -91,7 +95,8 @@ Content-Type: application/json
     "name": { "type": "string", "ipsum": "name" },
     "email": { "type": "string", "format": "email" },
     "bio": { "type": "string", "ipsum": "sentence" },
-    "age": { "type": "integer" }
+    "age": { "type": "integer" },
+    "avatar": { "type": "string", "ipsum": "small image" },
   }
 }
 ```
@@ -103,7 +108,8 @@ Content-Type: application/json
   "name": "Jonty Rhodes",
   "email": "john_laroche@troop.net",
   "bio": "Multiple copies were made of that original which were distributed to monasteries across England, where they were independently updated.",
-  "age": 51
+  "age": 51,
+  "avatar": "http://hhhhold.com/s?324332"
 }
 ```
 
@@ -302,11 +308,11 @@ String schemas may optionally have a hint, which is specified with the `"ipsum"`
 
   - <span class="api-str">`"long"`</span> - multiple paragraphs
 
-  - <span class="api-str">`"small image"`</span> - URL for an image with both dimensions between 100px and 250px
+  - <span class="api-str">`"small image"`</span> - URL for an image with width and height both randomly between 100px and 250px
 
-  - <span class="api-str">`"medium image"`</span> - URL for an image with both dimensions between 250px and 500px
+  - <span class="api-str">`"medium image"`</span> - URL for an image with width and height both randomly between 250px and 500px
 
-  - <span class="api-str">`"large image"`</span> - URL for an image with both dimensions between 500px and 900px
+  - <span class="api-str">`"large image"`</span> - URL for an image with width and height both randomly between 500px and 900px
 
 ## Bugs
 

--- a/src/schema.coffee
+++ b/src/schema.coffee
@@ -46,6 +46,10 @@ gen =
   id: (done) ->
     done null, uuid.v4()
 
+  image: (size, done) ->
+    params = {"small": "s", "medium": "m", "large": "l"}
+    done null, 'http://hhhhold.com/' + params[size.split(' ')[0]] + "?" + _.randomInt(0, 16777215)
+
   ipsumString: (schema, done) ->
     genFun = switch schema.ipsum
       when "id" then gen.id
@@ -59,6 +63,9 @@ gen =
       when "sentence" then gen.sentence
       when "paragraph" then (done) -> gen.paragraphs 1, done
       when "long" then (done) -> gen.paragraphs _.randomInt(1, 10), done
+      when "small image" then (done) -> gen.image schema.ipsum, done
+      when "medium image" then (done) -> gen.image schema.ipsum, done
+      when "large image" then (done) -> gen.image schema.ipsum, done
       else gen.sentence
     genFun done
 

--- a/src/schema.coffee
+++ b/src/schema.coffee
@@ -47,8 +47,7 @@ gen =
     done null, uuid.v4()
 
   image: (size, done) ->
-    params = {"small": "s", "medium": "m", "large": "l"}
-    done null, 'http://hhhhold.com/' + params[size.split(' ')[0]] + "?" + _.randomInt(0, 16777215)
+    done null, 'http://hhhhold.com/' + size + "?" + _.randomInt(0, 16777215)
 
   ipsumString: (schema, done) ->
     genFun = switch schema.ipsum
@@ -63,9 +62,9 @@ gen =
       when "sentence" then gen.sentence
       when "paragraph" then (done) -> gen.paragraphs 1, done
       when "long" then (done) -> gen.paragraphs _.randomInt(1, 10), done
-      when "small image" then (done) -> gen.image schema.ipsum, done
-      when "medium image" then (done) -> gen.image schema.ipsum, done
-      when "large image" then (done) -> gen.image schema.ipsum, done
+      when "small image" then (done) -> gen.image 's', done
+      when "medium image" then (done) -> gen.image 'm', done
+      when "large image" then (done) -> gen.image 'l', done
       else gen.sentence
     genFun done
 

--- a/test/api.coffee
+++ b/test/api.coffee
@@ -89,6 +89,9 @@ describe "string ipsum:", ->
   testIpsum "sentence"
   testIpsum "paragraph"
   testIpsum "long"
+  testIpsum "small image"
+  testIpsum "medium image"
+  testIpsum "large image"
 
 describe "multiple:", ->
   it "5 bools", (done) ->


### PR DESCRIPTION
Love schematic-ipsum for generating my test JSON.

Saw issue #3 and it seems like a good idea. I added it to the ipsum parameter, since it's a URL string.

Since you're going for randomized text to give the data a "lived in" feel, I used hhhhold.com because it delivers slightly randomized content, and not just the same static image to each instance like placehold.it would.
